### PR TITLE
Numpy NDArray not instance of list causes plot to fail as color array is invalid

### DIFF
--- a/phaseportrait/Trajectories2D.py
+++ b/phaseportrait/Trajectories2D.py
@@ -73,7 +73,7 @@ class Trajectory2D(trajectory):
         
         linez = LineCollection(segments[:,:,(0,1)], linewidth=self.size, color=C)
         self.ax['Z'].add_collection(linez)
-        if isinstance(C, list):
+        if isinstance(C, list) or isinstance(C, np.ndarray): 
             C = C[0]
         self.ax['Z'].plot([val_init[0],val[0,0]], [val_init[1], val[1,0]], '-', linewidth=self.size, color=C, zorder=-1)
         # self.ax['Z'].plot(val[0,1:], val[1,1:], label=f"({','.join(tuple(map(str, val_init)))})")

--- a/phaseportrait/Trajectories3D.py
+++ b/phaseportrait/Trajectories3D.py
@@ -95,7 +95,7 @@ class Trajectory3D(trajectory):
         self.ax['Z'].add_collection(linez)
 
 
-        if isinstance(C, list): 
+        if isinstance(C, list) or isinstance(C, np.ndarray):
             C = C[0]
         self.ax['3d'].plot(*[[val_init[i],val[i,0]] for i in range(3)], '-', linewidth=self.size, color=C)
         self.ax['X'].plot([val_init[1],val[1,0]], [val_init[2], val[2,0]], '-', linewidth=self.size, color=C, zorder=-1)

--- a/phaseportrait/trajectories/trajectory.py
+++ b/phaseportrait/trajectories/trajectory.py
@@ -69,6 +69,8 @@ class trajectory:
                     exceptions.dFArgsRequired()
         except KeyError:
             pass
+        except ModuleNotFoundError:
+            pass
 
         # Genral Runge-Kutta variables
         self.runge_kutta_step = runge_kutta_step


### PR DESCRIPTION
Seems like on newer versions of numpy a ndarray is no longer returns true on `isinstance(..., list)`.
The color array must be unpackd before plotting, so this causes an exception as the color array is invalid as a color tuple.